### PR TITLE
Prevent unresolved symbol error

### DIFF
--- a/pam_close_systemd_system_dbus.c
+++ b/pam_close_systemd_system_dbus.c
@@ -36,3 +36,10 @@ pam_sm_open_session(pam_handle_t *pamh, int flags,
     pam_close_systemd_system_dbus(pamh);
     return PAM_SUCCESS;
 }
+
+int
+pam_sm_close_session(pam_handle_t *pamh, int flags,
+		     int argc, const char **argv)
+{
+    return PAM_SUCCESS;
+}


### PR DESCRIPTION
This commit fixes the following PAM warning when a session closes

    PAM unable to resolve symbol: pam_sm_close_session